### PR TITLE
Fix GetClubStats request context and response unmarshaling

### DIFF
--- a/REQUESTS.md
+++ b/REQUESTS.md
@@ -277,7 +277,6 @@ Retrieves detailed information about the club that a specific player belongs to.
   }
 }
 ```
-#### Clubs/GetStats v1
 #### Clubs/InviteToClub v4
 Invites a player to join the club.
 

--- a/clubs.go
+++ b/clubs.go
@@ -101,14 +101,6 @@ type ClubSeasonalTitle struct {
 	Title string `json:"Title"`
 }
 
-// ClubStatsData represents the complete statistics data for a club member
-type ClubStatsData struct {
-	CareerStats            ClubCareerStats     `json:"CareerStats"`
-	SeasonalStats          []ClubSeasonalStat  `json:"SeasonalStats"`
-	PreviousSeasonalBadges []interface{}       `json:"PreviousSeasonalBadges"`
-	SeasonalTitles         []ClubSeasonalTitle `json:"SeasonalTitles"`
-}
-
 type GetClubDetailsRequest struct {
 	ClubID ClubID `json:"ClubID"`
 }
@@ -165,12 +157,12 @@ type AcceptClubInviteResponse struct {
 	ClubDetails ClubDetails `json:"ClubDetails"`
 }
 
-type LeaveClubRequest struct {
-	ClubID ClubID `json:"ClubID"`
-}
-
+// GetStatsResponse represents the complete statistics data for a club member
 type GetStatsResponse struct {
-	Stats ClubStatsData `json:"Stats"`
+	CareerStats            ClubCareerStats     `json:"CareerStats"`
+	SeasonalStats          []ClubSeasonalStat  `json:"SeasonalStats"`
+	PreviousSeasonalBadges []interface{}       `json:"PreviousSeasonalBadges"`
+	SeasonalTitles         []ClubSeasonalTitle `json:"SeasonalTitles"`
 }
 
 type GetClubTitleInstancesResponse struct {
@@ -237,14 +229,9 @@ func (p *PsyNetRPC) UpdateClub(ctx context.Context, request *UpdateClubRequest) 
 }
 
 // GetClubStats retrieves statistics for the current player's club.
-// Note: We pass PlayerID in the request because PsyNet often returns zeros for empty requests.
-func (p *PsyNetRPC) GetClubStats(ctx context.Context, playerID PlayerID) (*ClubStatsData, error) {
-	request := map[string]PlayerID{
-		"PlayerID": playerID,
-	}
-
-	var result ClubStatsData
-	err := p.sendRequestSync(ctx, "Clubs/GetStats v1", request, &result)
+func (p *PsyNetRPC) GetClubStats(ctx context.Context) (*GetStatsResponse, error) {
+	var result GetStatsResponse
+	err := p.sendRequestSync(ctx, "Clubs/GetStats v1", &emptyRequest{}, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/clubs.go
+++ b/clubs.go
@@ -237,13 +237,18 @@ func (p *PsyNetRPC) UpdateClub(ctx context.Context, request *UpdateClubRequest) 
 }
 
 // GetClubStats retrieves statistics for the current player's club.
-func (p *PsyNetRPC) GetClubStats(ctx context.Context) (*ClubStatsData, error) {
-	var result GetStatsResponse
-	err := p.sendRequestSync(ctx, "Clubs/GetStats v1", &emptyRequest{}, &result)
+// Note: We pass PlayerID in the request because PsyNet often returns zeros for empty requests.
+func (p *PsyNetRPC) GetClubStats(ctx context.Context, playerID PlayerID) (*ClubStatsData, error) {
+	request := map[string]PlayerID{
+		"PlayerID": playerID,
+	}
+
+	var result ClubStatsData
+	err := p.sendRequestSync(ctx, "Clubs/GetStats v1", request, &result)
 	if err != nil {
 		return nil, err
 	}
-	return &result.Stats, nil
+	return &result, nil
 }
 
 // GetClubTitleInstances retrieves title instances for a club.


### PR DESCRIPTION
Was vibe coding with Gemini and stumbled across this.  Without this the response values were always 0 for club stats.