### PR TITLE
Handle WebSocket Closing Error

### DIFF
--- a/psynetrpc.go
+++ b/psynetrpc.go
@@ -3,8 +3,10 @@ package rlapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -199,16 +201,12 @@ func (p *PsyNetRPC) readMessages() {
 	for {
 		_, message, err := p.wsConn.ReadMessage()
 		if err != nil {
-		    p.mu.Lock()
-		    expected := !p.connected
-		    p.mu.Unlock()
-		
-		    if expected {
-		        p.logger.Debug("websocket closed normally", slog.Any("err", err))
-		    } else {
-		        p.logger.Error("failed to read websocket message", slog.Any("err", err))
-		    }
-		    break
+			if errors.Is(err, net.ErrClosed) {
+				p.logger.Debug("websocket closed", slog.Any("err", err))
+			} else {
+				p.logger.Error("failed to read websocket message", slog.Any("err", err))
+			}
+			break
 		}
 
 		if strings.HasPrefix(string(message), "PsyPong:") {

--- a/psynetrpc.go
+++ b/psynetrpc.go
@@ -199,8 +199,16 @@ func (p *PsyNetRPC) readMessages() {
 	for {
 		_, message, err := p.wsConn.ReadMessage()
 		if err != nil {
-			p.logger.Error("failed to read websocket message", slog.Any("err", err))
-			break
+		    p.mu.Lock()
+		    expected := !p.connected
+		    p.mu.Unlock()
+		
+		    if expected {
+		        p.logger.Debug("websocket closed normally", slog.Any("err", err))
+		    } else {
+		        p.logger.Error("failed to read websocket message", slog.Any("err", err))
+		    }
+		    break
 		}
 
 		if strings.HasPrefix(string(message), "PsyPong:") {


### PR DESCRIPTION
## Fix false ERROR log on intentional WebSocket close

### Problem

When `Close()` is called explicitly on a `PsyNetRPC` instance, the internal `readMessages()` goroutine is blocked on `wsConn.ReadMessage()`. Closing the underlying TCP socket causes `ReadMessage()` to return a `use of closed network connection` error, which is then logged as `ERROR`:

```
{"level":"ERROR","msg":"failed to read websocket message","err":"read tcp 172.22.0.8:38354->34.149.116.40:443: use of closed network connection"}
```

This is misleading — the connection was closed intentionally, not due to a real network failure. A common pattern that triggers this is opening a short-lived RPC connection per request:

```go
rpc, _, err := GetRPC(psyNet, player)
if err != nil {
    return err
}
defer rpc.Close() // closes the socket → readMessages logs a false ERROR

profiles, err := rpc.GetProfiles(ctx, playerIDs)
```

### Root cause

`readMessages()` does not distinguish between an expected closure (triggered by `Close()`) and an unexpected network error. Both are logged at `ERROR` level.

### Fix

Check the `connected` flag — which is already set to `false` by `Close()` before the socket is closed — to determine whether the error is expected:

```go
if err != nil {
    p.mu.Lock()
    expected := !p.connected
    p.mu.Unlock()

    if expected {
        p.logger.Debug("websocket closed normally", slog.Any("err", err))
    } else {
        p.logger.Error("failed to read websocket message", slog.Any("err", err))
    }
    break
}
```

This way, intentional closures are logged at `DEBUG` level, while real unexpected errors remain at `ERROR`.

### Why not `websocket.IsUnexpectedCloseError`?

`use of closed network connection` is a raw TCP-level error, not a WebSocket close frame. `IsUnexpectedCloseError` only handles proper WebSocket close codes and would not catch this case.